### PR TITLE
Use emojis to visually separate twinspark log messages

### DIFF
--- a/twinspark.js
+++ b/twinspark.js
@@ -205,7 +205,7 @@
     var event = new CustomEvent(type, {bubbles: bubbles,
                                        cancelable: true,
                                        detail: opts.detail});
-    console.debug('EVENT', type, {el: el, detail: opts.detail});
+    console.debug('🛎️ EVENT', type, {el: el, detail: opts.detail});
     el.dispatchEvent(event);
     return event;
   }
@@ -1169,7 +1169,8 @@
 
     return action.commands.reduce(function(p, command) {
       return p.then(function(rv) {
-        console.debug('COMMAND', command.src, {input: rv, src: action.src});
+        console.debug(rv !== false ? '🔵' : '🚫', 'COMMAND',
+                      command.src, {input: rv, src: action.src});
         // `false` indicates that action should stop
         if (rv === false)
           return rv;


### PR DESCRIPTION
When working with a large number of twinspark actions, the browser console becomes very crowded. We can use emojis to reduce the visual noise. This is especially useful to distinguish commands that will be executed from those that are prevented (e.g. because of some command returning `false`)

<img width="389" alt="image" src="https://user-images.githubusercontent.com/204759/163205447-69a84513-cd97-4f89-a9e3-9726cf1acd4a.png">
