### PR TITLE
Create `target` keyword for twinspark.query

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,7 +418,7 @@
 </div>
 
 
-<h3 id="target" class="mt-p">Relative targeting</h3>
+<h3 id="target-target" class="mt-p">Relative targeting</h3>
 <p>Most twinspark commands and extensions operate directly on the current
   target element. However, some of them work might require a pair of elements
   (e.g. a command that copies data from one input to another). This means
@@ -433,14 +433,14 @@
   </div>
 
   <div class="card-body">
-    <p>Press here
+    <p>Click here
       <input type="button" class="btn" ts-trigger="click" ts-action="valueToValue target 'parent .card-body | .result'" value="value" />
       or here
       <input type="button" class="btn" ts-trigger="click" ts-action="valueToValue target 'parent .card-body | .result'" value="another value" />
     </p>
-    <p>To see a copy here:
+    <p>to copy the value here:
       <input type="text" class="result" disabled /></p>
-    <p>Press one of these buttons to rename it:
+    <p>Click one of these buttons to rename it with the value above:
       <input type="button" class="btn" value="one" ts-trigger="click" ts-action="valueToValue 'parent .card-body | .result' target">
        or
        <input type="button" class="btn" value="two" ts-trigger="click" ts-action="valueToValue 'parent .card-body | .result' target">

--- a/index.html
+++ b/index.html
@@ -420,9 +420,9 @@
 
 <h3 id="target-target" class="mt-p">Relative targeting</h3>
 <p>Most twinspark commands and extensions operate directly on the current
-  target element. However, some of them work might require a pair of elements
+  target element. However, some of them might require a pair of elements
   (e.g. a command that copies data from one input to another). This means
-  directly supplying a twinspark selector as an argument. To point directly to
+  supplying a twinspark selector as an argument. To point directly to
   the current target element, use the <code>target</code> keyword.</p>
 
 <div class="card">

--- a/index.html
+++ b/index.html
@@ -418,6 +418,79 @@
 </div>
 
 
+<h3 id="target" class="mt-p">Relative targeting</h3>
+<p>Most twinspark commands and extensions operate directly on the current
+  target element. However, some of them work might require a pair of elements
+  (e.g. a command that copies data from one input to another). This means
+  directly supplying a twinspark selector as an argument. To point directly to
+  the current target element, use the <code>target</code> keyword.</p>
+
+<div class="card">
+  <div class="card-header">
+    <h5 class="d-inline mr-2">Demo</h5>
+    <button class="btn btn-link btn-sm reset">Reset</button>
+    <button class="btn btn-link btn-sm source">View Source</button>
+  </div>
+
+  <div class="card-body">
+    <p>Press here
+      <input type="button" class="btn" ts-trigger="click" ts-action="valueToValue target 'parent .card-body | .result'" value="value" />
+      or here
+      <input type="button" class="btn" ts-trigger="click" ts-action="valueToValue target 'parent .card-body | .result'" value="another value" />
+    </p>
+    <p>To see a copy here:
+      <input type="text" class="result" disabled /></p>
+    <p>Press one of these buttons to rename it:
+      <input type="button" class="btn" value="one" ts-trigger="click" ts-action="valueToValue 'parent .card-body | .result' target">
+       or
+       <input type="button" class="btn" value="two" ts-trigger="click" ts-action="valueToValue 'parent .card-body | .result' target">
+    </p>
+  </div>
+
+  <script>
+  twinspark.func({
+    valueToValue: function (sourceSel, targetSel, o) {
+      const source = twinspark.query(o.el, sourceSel);
+      const target = twinspark.query(o.el, targetSel);
+      target.value = source.value;
+    },
+  });
+  </script>
+</div>
+
+<br/>
+<p>Another useful target is the element that created the event. The simplest
+  way to access it is to create a twinspark extension that sets
+  <code>target</code> to <code>event.target</code>:</p>
+
+<div class="card">
+  <div class="card-header">
+    <h5 class="d-inline mr-2">Demo</h5>
+    <button class="btn btn-link btn-sm reset">Reset</button>
+    <button class="btn btn-link btn-sm source">View Source</button>
+  </div>
+
+  <div class="card-body">
+    <div ts-trigger="click" ts-action="prevent, targetSource, class^ active">
+      <p>None of these buttons have <code>ts-actions</code>, but when you click,
+        the event is bubbled to the container that executes commands:<br/>
+        <a href="" class="btn">One</a>
+        <a href="" class="btn">Two</a>
+        <a href="" class="btn">Three</a>
+      </p>
+    </div>
+  </div>
+
+  <script>
+  twinspark.func({
+    targetSource: function (o) {
+      o.el = o.event.target;
+    },
+  });
+  </script>
+</div>
+
+
 <h3 id="history" class="mt-p">Changing URLs</h3>
 <p>URLs are a fundament of the Web. Changing URLs in line with activity makes your
   app reloadable, browseable with backward/forward button and overall a good

--- a/twinspark.js
+++ b/twinspark.js
@@ -570,6 +570,10 @@
       return el;
     }
 
+    if (sel == 'target') {
+      return el;
+    }
+
     if (sel == 'inherit') {
       var parent = el.parentElement.closest('[ts-target]');
       return findTarget(parent);


### PR DESCRIPTION
It is useful to target the element that is the origin of the event. I have created a very artificial example, but it still proves that we can save on the code length and id/class identifiers.

<img width="830" alt="image" src="https://user-images.githubusercontent.com/204759/163206404-f5f1ac71-c969-4cab-979c-77e3ade7c632.png">
