### PR TITLE
Feature/cancelling requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -1130,7 +1130,7 @@ than it'll only restore HTML for the first 3 clicks</p>
     <p>Every other request is slow</p>
     <p><input type="text"
               name="q"
-              ts-req-before="cancelCurrentXHR"
+              ts-req-before="abortActiveXHR"
               ts-req="/cancelling-autocomplete"
               ts-trigger="keyup changed delay 100"
               ts-target="#search-results-2"
@@ -1141,35 +1141,22 @@ than it'll only restore HTML for the first 3 clicks</p>
 
   <script>
     function delay(mock, ms) {
-      return (req, res) => {
-        const ret =
-          typeof mock === 'function'
-            ? mock(req, res)
-            : createResponseFromObject(mock);
-        if (ret === undefined) {
-          return undefined;
-        }
-        return Promise.resolve(ret).then(val => {
-          if (val == undefined) {
-            return undefined;
-          } else {
-            return new Promise(resolve => {
-              var after = typeof ms === 'function' ? ms() : ms;
-              console.debug('Delaying', Math.round(after, 2)/1000., 'sec');
-
-              return setTimeout(() => resolve(val), after)
-            });
-          }
+      return (req, res) =>
+        Promise.resolve(mock(req, res)).then(val => {
+          return new Promise(resolve => {
+            const after = ms();
+            console.debug('⌛ Delaying', Math.round(after, 2)/1000., 'sec');
+            return setTimeout(() => resolve(val), after, true);
+          });
         });
-      };
-    }
+    };
 
     twinspark.func({
-      cancelCurrentXHR: function(o) {
+      abortActiveXHR: function(o) {
           const xhr = o.el['ts-active-xhr'];
-          console.log('Checking current XHR', xhr);
+          console.log('🔍 Looking for active XHR');
           if (xhr) {
-              console.log('ABORTED!', xhr);
+              console.log('⛔ ABORTED!', String(xhr.req.url()));
               xhr.abort();
           }
       },
@@ -1178,8 +1165,8 @@ than it'll only restore HTML for the first 3 clicks</p>
     var counter = 0;
 
     XHRMock.get(/\/cancelling-autocomplete/, delay(function(req, res) {
-      var q = ('Query ' + (counter+1) +
-               ' (' + (counter % 2 == 0 ? 'fast' : 'slow') + '): '
+      var q = ('Query ' + (counter+1)
+               + ' (' + (counter % 2 === 0 ? 'fast' : 'slow') + '): '
                + req.url().query.q);
       var now = +new Date;
       return res.status(200).body('<div>' +

--- a/index.html
+++ b/index.html
@@ -1116,8 +1116,15 @@ than it'll only restore HTML for the first 3 clicks</p>
 <p>When autocomplete triggers a time-consuming operation (e.g. full-text search),
   the implementation above triggers numerous requests if the user types slow enough.
   If requests finish at different durations, an older request can override the
-  latest. To avoid this, we need to abort the XHR.
-</p>
+  latest. To avoid this, we need to abort the XHR using <code>ts-req-strategy="last"</code>.</p>
+<p>Possible values for <code>ts-req-strategy</code> are:</p>
+<ol>
+  <li><code>first</code> prevent triggering new requests until the active one finishes
+    (useful for forms)</li>
+  <li><code>last</code> abort active request when a new one is triggered</li>
+  <li><code>queue</code> (default) send requests as they are triggered</li>
+</ol>
+<br/>
 
 <div class="card">
   <div class="card-header">
@@ -1130,7 +1137,7 @@ than it'll only restore HTML for the first 3 clicks</p>
     <p>Every other request is slow</p>
     <p><input type="text"
               name="q"
-              ts-req-before="abortActiveXHR"
+              ts-req-strategy="last"
               ts-req="/cancelling-autocomplete"
               ts-trigger="keyup changed delay 100"
               ts-target="#search-results-2"
@@ -1150,17 +1157,6 @@ than it'll only restore HTML for the first 3 clicks</p>
           });
         });
     };
-
-    twinspark.func({
-      abortActiveXHR: function(o) {
-          const xhr = o.el['ts-active-xhr'];
-          console.log('🔍 Looking for active XHR');
-          if (xhr) {
-              console.log('⛔ ABORTED!', String(xhr.req.url()));
-              xhr.abort();
-          }
-      },
-    });
 
     var counter = 0;
 

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         });
       });
 
-      [].forEach.call(document.querySelectorAll('h3'), function(el) {
+      [].forEach.call(document.querySelectorAll('h3, h4'), function(el) {
         if (el.id && !el.querySelector('.anchor')) {
           var a = makeel('a', {href: '#' + el.id, className: 'anchor'}, '#');
           el.append(' ');
@@ -1107,6 +1107,88 @@ than it'll only restore HTML for the first 3 clicks</p>
                         .join('')) +
                       '</div>');
     });
+  </script>
+</div>
+
+
+<br/>
+<h4 id="cancelling-autocomplete">Making it economical</h4>
+<p>When autocomplete triggers a time-consuming operation (e.g. full-text search),
+  the implementation above triggers numerous requests if the user types slow enough.
+  If requests finish at different durations, an older request can override the
+  latest. To avoid this, we need to abort the XHR.
+</p>
+
+<div class="card">
+  <div class="card-header">
+    <h5 class="d-inline mr-2">Demo</h5>
+    <button class="btn btn-link btn-sm reset">Reset</button>
+    <button class="btn btn-link btn-sm source">View Source</button>
+  </div>
+
+  <div class="card-body">
+    <p>Every other request is slow</p>
+    <p><input type="text"
+              name="q"
+              ts-req-before="cancelCurrentXHR"
+              ts-req="/cancelling-autocomplete"
+              ts-trigger="keyup changed delay 100"
+              ts-target="#search-results-2"
+              ts-swap="inner"
+              placeholder="Search..."/></p>
+    <div id="search-results-2"></div>
+  </div>
+
+  <script>
+    function delay(mock, ms) {
+      return (req, res) => {
+        const ret =
+          typeof mock === 'function'
+            ? mock(req, res)
+            : createResponseFromObject(mock);
+        if (ret === undefined) {
+          return undefined;
+        }
+        return Promise.resolve(ret).then(val => {
+          if (val == undefined) {
+            return undefined;
+          } else {
+            return new Promise(resolve => {
+              var after = typeof ms === 'function' ? ms() : ms;
+              console.debug('Delaying', Math.round(after, 2)/1000., 'sec');
+
+              return setTimeout(() => resolve(val), after)
+            });
+          }
+        });
+      };
+    }
+
+    twinspark.func({
+      cancelCurrentXHR: function(o) {
+          const xhr = o.el['ts-active-xhr'];
+          console.log('Checking current XHR', xhr);
+          if (xhr) {
+              console.log('ABORTED!', xhr);
+              xhr.abort();
+          }
+      },
+    });
+
+    var counter = 0;
+
+    XHRMock.get(/\/cancelling-autocomplete/, delay(function(req, res) {
+      var q = ('Query ' + (counter+1) +
+               ' (' + (counter % 2 == 0 ? 'fast' : 'slow') + '): '
+               + req.url().query.q);
+      var now = +new Date;
+      return res.status(200).body('<div>' +
+                      ('one two three four five six seven'
+                        .split(' ')
+                        .map(s => '<p>' + q + ' ' + s + ' ' + now + '</p>')
+                        .join('')) +
+                      '</div>');
+    }, () => 500 + (counter++ % 2) * 2000));
   </script>
 </div>
 

--- a/twinspark.js
+++ b/twinspark.js
@@ -319,23 +319,24 @@
 
   /** @type {function(string, RequestInit): Promise<*> } */
   function xhr(url, opts) {
-    return new Promise(function(resolve, reject) {
-      opts || (opts = {});
+    var xhr = new XMLHttpRequest();
+    return {
+      promise: new Promise(function(resolve, reject) {
+        opts || (opts = {});
 
-      var xhr = new XMLHttpRequest();
-      xhr.open(opts.method || 'GET', url, true);
-      for (var k in opts.headers) {
-        xhr.setRequestHeader(k, opts.headers[k]);
-      }
+        xhr.open(opts.method || 'GET', url, true);
+        for (var k in opts.headers) {
+          xhr.setRequestHeader(k, opts.headers[k]);
+        }
 
-      xhr.onreadystatechange = function() {
-        if (xhr.readyState != 4) return;
-        if (xhr.status == 0) return; // timeout
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState != 4) return;
+          if (xhr.status == 0) return; // timeout
 
-        var headers = {'ts-title':     xhr.getResponseHeader('ts-title'),
-                       'ts-history':   xhr.getResponseHeader('ts-history'),
-                       'ts-swap':      xhr.getResponseHeader('ts-swap'),
-                       'ts-swap-push': xhr.getResponseHeader('ts-swap-push')}
+          var headers = {'ts-title':     xhr.getResponseHeader('ts-title'),
+                         'ts-history':   xhr.getResponseHeader('ts-history'),
+                         'ts-swap':      xhr.getResponseHeader('ts-swap'),
+                         'ts-swap-push': xhr.getResponseHeader('ts-swap-push')}
 
         return resolve({xhr:     xhr,
                         opts:    opts,
@@ -346,18 +347,20 @@
                         headers: headers,
                         content: xhr.responseText});
 
-      }
+        }
 
-      xhr.timeout = xhrTimeout;
-      xhr.ontimeout = function() {
-        return reject({ok:    false,
-                       url:   url,
-                       error: "timeout"});
-      }
+        xhr.timeout = xhrTimeout;
+        xhr.ontimeout = function() {
+          return reject({ok:    false,
+                         url:   url,
+                         error: "timeout"});
+        }
 
-      var body = /** @type {(ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined)} */ (opts.body);
-      xhr.send(body);
-    });
+        var body = /** @type {(ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined)} */ (opts.body);
+        xhr.send(body);
+      }),
+      xhr: xhr
+    };
   }
 
 
@@ -884,17 +887,27 @@
     }
 
     var origins = batch.map(function(req) { return req.el; });
+
+    var query = xhr(fullurl, opts);
+
     origins.forEach(function (el) {
       el.setAttribute('aria-busy', 'true');
       el.classList.add('ts-active');
+      el['ts-active-xhr'] = query.xhr;
     });
 
-    return xhr(fullurl, opts)
+    return query.promise
       .then(function(res) {
+
         onidle(() => origins.forEach(el => {
           el.removeAttribute('aria-busy');
-          el.classList.remove('ts-active')
+          el.classList.remove('ts-active');
+          delete el['ts-active-xhr'];
         }));
+
+        if (query.xhr.isAborted) {
+          return false;
+        }
 
         // res.url == "" with mock-xhr
         if (res.ok && res.url && (res.url != new URL(fullurl, location.href).href)) {
@@ -913,7 +926,8 @@
       .catch(function(res) {
         onidle(() => origins.forEach(el => {
           el.removeAttribute('aria-busy');
-          el.classList.remove('ts-active')
+          el.classList.remove('ts-active');
+          delete el['ts-active-xhr'];
         }));
 
         ERR('Error retrieving backend response', fullurl, res.error || res);


### PR DESCRIPTION
Components like autocompletes can trigger numerous expensive XHR requests. Typically this is solved with the debouncing technique: the requests are sent only when a specific downtime has passed. This does not work so well when requests take more time than the natural human typing timescale of ~200-300ms.  Then, the user may trigger a `slow` request and a `fast` one right after that. The `fast` request quickly finishes, showing suggestions. Then the `slow` one finishes, triggers the same processing code, and wipes out the correct output with stale suggestions.

The simplest way to avoid this situation is to keep the created XHR object and store it somewhere. When another request is triggered, we can `abort()` the old one and drop the promise chain.