### PR TITLE
WIP: Fix the empty URLSearchParams on Safari

### DIFF
--- a/twinspark.js
+++ b/twinspark.js
@@ -1297,6 +1297,7 @@
       swapped = swapped.concat(viaheader.flat());
     swapped = distinct(swapped);
     swapped.forEach(function(el) {
+      if (!el) return;
       processScripts(el);
       activate(el);
       autofocus(el);
@@ -1386,7 +1387,7 @@
     }
 
     // convert FormData to string so we can evade multipart form
-    var simplebody = new URLSearchParams(body);
+    var simplebody = new URLSearchParams(Array.from(body));
     opts.body = simplebody.toString();
     opts.headers['Content-Type'] = 'application/x-www-form-urlencoded';
     return opts;
@@ -1401,7 +1402,7 @@
       return mergeParams(acc, req.opts.data);
     }, new FormData());
 
-    var qs = method == 'GET' ? new URLSearchParams(data).toString() : null;
+    var qs = method == 'GET' ? new URLSearchParams(Array.from(data)).toString() : null;
     var body = method != 'GET' ? data : null;
 
     var opts = {
@@ -2052,6 +2053,9 @@
     window.addEventListener('popstate', onpopstate);
     // Store HTML before going to other page
     window.addEventListener('beforeunload', storeCurrentState);
+    // for iphone instead of beforeunload
+    window.addEventListener('pagehide', storeCurrentState);
+
     activate(document.body);
     READY = true;
     console.debug('init done', _e);


### PR DESCRIPTION
IOs Safari cannot create URLSearchParams from ForData -_-

Also there may be no `beforeunload` event